### PR TITLE
Node 12.x to Node 16.x; Resource attribute reference

### DIFF
--- a/cloudfront-logs/lambda.tf
+++ b/cloudfront-logs/lambda.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function" "this" {
   function_name = "${var.name_prefix}-${var.name}"
 
-  runtime                        = "nodejs12.x"
+  runtime                        = "nodejs16.x"
   handler                        = "index.handler"
   timeout                        = 5
   reserved_concurrent_executions = 3

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 resource "aws_cloudfront_distribution" "site_distribution" {
   origin {
-    domain_name = aws_s3_bucket.site.website_endpoint
+    domain_name = aws_s3_bucket_website_configuration.site.website_endpoint
     origin_id   = "S3Origin-${aws_s3_bucket.site.bucket}"
 
     origin_shield {


### PR DESCRIPTION
* [Node 12.x to Node 16.x](https://github.com/joshbeard/tf-aws-site/commit/499e2163e1e360bb3805726fffe1e3a2623e61bb)
* [Update website endpoint reference](https://github.com/joshbeard/tf-aws-site/commit/190312362e1bc1003980ecca9c8c17bf79af75e8) 

Reference the s3 website endpoint from the
'aws_s3_bucket_website_configuration' resource instead of the
'aws_s3_bucket' resource. The latter is deprecated.